### PR TITLE
Update character-creation.md

### DIFF
--- a/character-creation.md
+++ b/character-creation.md
@@ -38,9 +38,9 @@ Adventuring is a profession, and all Characters have undergone extensive trainin
 1. **Record Attack Bonus**. Your character has a certain degree of basic combat competence based on their class. This bonus increases as you advance in character levels and is added to your attack roll. A new character’s attack bonus is usually +0, though [Warriors](/classes#warrior) start with a +1 attack bonus.
 
 1. **Record Derived Statistics**. Record your [Physical](/rules#physical) (exhaustion, poison, etc), [Evasion](/rules#evasion) (explosions, traps, etc), and [Mental](/rules#mental) (mind control, tests of will, etc) [Saving Throws](/rules#saving-throws).
-  - Your [Physical](/rules#physical) score is 15 minus the greater of your STR and CON.
-  - Your [Evasion](/rules#evasion) score is 15 minus the greater of your INT and DEX.
-  - Your [Mental](/rules#mental) score is 15 minus the gerater of your INT and WIS.
+  - Your [Physical](/rules#physical) score is 15 minus the greater between your STR and CON.
+  - Your [Evasion](/rules#evasion) score is 15 minus the greater between your INT and DEX.
+  - Your [Mental](/rules#mental) score is 15 minus the gerater between your INT and WIS.
   - Record your maximum [System Strain](/rules#system-strain), which is equal to your Constitution.
 
 1. **Choose Starting Gear**. Gain `3d6 x 10` gold to spend on [gear](/equipment) (ignoring [Equipment Availability](/equipment#equipment-availability)), noting their [Encumbrance](/rules#encumbrance) and whether they are [Readied](/rules#readied) or [Stowed](/rules#stowed). You may carry [Readied](/rules#readied) equipment equal to half your Strength rounded down. You may carry [Stowed](/rules#stowed) equipment equal to your Strength. Other party members may be willing to Stow gear for you.


### PR DESCRIPTION
Using your previous example, the use of the word "between" eliminates the ambiguity and makes "and" add precision and makes it the best choice over "or".